### PR TITLE
Add `TemporaryChannelLevel` (`TCL`) command support

### DIFF
--- a/src/aioonkyo/export/instruction/command.py
+++ b/src/aioonkyo/export/instruction/command.py
@@ -7,6 +7,7 @@ from ...instruction import (
     ListeningModeCommand as ListeningMode,
     MutingCommand as Muting,
     PowerCommand as Power,
+    TemporaryChannelLevelCommand as TemporaryChannelLevel,
     ToneCommand as Tone,
     TunerPresetCommand as TunerPreset,
     TVOperationCommand as TVOperation,

--- a/src/aioonkyo/export/instruction/query.py
+++ b/src/aioonkyo/export/instruction/query.py
@@ -11,6 +11,7 @@ from ...instruction import (
     MutingQuery as Muting,
     PowerQuery as Power,
     TemperatureQuery as Temperature,
+    TemporaryChannelLevelQuery as TemporaryChannelLevel,
     ToneQuery as Tone,
     TunerPresetQuery as TunerPreset,
     VideoInformationQuery as VideoInformation,

--- a/src/aioonkyo/export/status.py
+++ b/src/aioonkyo/export/status.py
@@ -15,6 +15,7 @@ from ..status import (
     RawStatus as Raw,
     Status as Status,
     TemperatureStatus as Temperature,
+    TemporaryChannelLevelStatus as TemporaryChannelLevel,
     ToneStatus as Tone,
     TunerPresetStatus as TunerPreset,
     ValidStatus as Valid,

--- a/src/aioonkyo/instruction.py
+++ b/src/aioonkyo/instruction.py
@@ -17,6 +17,7 @@ from .parameter import (
     TVOperationParam,
     VolumeParamEnum,
     VolumeParamNumeric,
+    TemporaryChannelLevelNumeric,
 )
 
 
@@ -61,6 +62,11 @@ class MutingQuery(_Query):
 @dataclass
 class ChannelMutingQuery(_MainZoneInstructionMixin, _Query):
     kind: ClassVar[Kind] = Kind.CHANNEL_MUTING
+
+
+@dataclass
+class TemporaryChannelLevelQuery(_MainZoneInstructionMixin, _Query):
+    kind: ClassVar[Kind] = Kind.TEMPORARY_CHANNEL_LEVEL
 
 
 @dataclass
@@ -268,10 +274,53 @@ class ChannelMutingCommand(_ChannelMutingCommand):
     Param: TypeAlias = MutingParam
 
 
+# needs to be a dataclass because it inherits from two dataclasses
+@dataclass(kw_only=True)
+class _TemporaryChannelLevelCommand(_MainZoneInstructionMixin, _Instruction):
+    kind: ClassVar[Kind] = Kind.TEMPORARY_CHANNEL_LEVEL
+    # Each channel is represented as a simple int in range [-16, 16].
+    # The dataclass contains one attribute per channel (default 0).
+    front_left: int = 0
+    front_right: int = 0
+    center: int = 0
+    surround_left: int = 0
+    surround_right: int = 0
+    surround_back_left: int = 0
+    surround_back_right: int = 0
+    subwoofer: int = 0
+    height_1_left: int = 0
+    height_1_right: int = 0
+    height_2_left: int = 0
+    height_2_right: int = 0
+    subwoofer_2: int = 0
+
+    parameter: bytes = field(init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        parts: list[bytes] = []
+        for param, val in vars(self).items():
+            if isinstance(val, Kind):
+                continue
+            if not isinstance(val, int):
+                raise TypeError(f"Channel {param} must be int, got {type(val).__name__}")
+            # encode single int to 3-char ASCII using helper
+            enc = TemporaryChannelLevelNumeric.from_numeric(val)
+            parts.append(enc.raw)
+
+        self.parameter = b"".join(parts)
+        self._validate()
+
+
+class TemporaryChannelLevelCommand(_TemporaryChannelLevelCommand):
+    # TypeAlias doesn't work in dataclasses
+    Param: TypeAlias = int
+
+
 type KnownQuery = (
     PowerQuery
     | MutingQuery
     | ChannelMutingQuery
+    | TemporaryChannelLevelQuery
     | VolumeQuery
     | ToneQuery
     | InputSourceQuery
@@ -296,6 +345,7 @@ type KnownCommand = (
     | TunerPresetCommand
     | ToneCommand
     | ChannelMutingCommand
+    | TemporaryChannelLevelCommand
 )
 
 type KnownInstruction = KnownQuery | KnownCommand

--- a/src/aioonkyo/message_code.py
+++ b/src/aioonkyo/message_code.py
@@ -25,6 +25,7 @@ class Kind(Enum):
     POWER = auto()
     MUTING = auto()
     CHANNEL_MUTING = auto()
+    TEMPORARY_CHANNEL_LEVEL = auto()
     VOLUME = auto()
     TONE = auto()
     INPUT_SOURCE = auto()
@@ -101,6 +102,8 @@ class Code(CodeBase):
     MT4 = Kind.MUTING, Zone.ZONE4
     # CHANNEL MUTING
     CMT = Kind.CHANNEL_MUTING, Zone.MAIN
+    # TEMPORARY CHANNEL LEVEL
+    TCL = Kind.TEMPORARY_CHANNEL_LEVEL, Zone.MAIN
     # VOLUME
     MVL = Kind.VOLUME, Zone.MAIN
     ZVL = Kind.VOLUME, Zone.ZONE2

--- a/src/aioonkyo/parameter.py
+++ b/src/aioonkyo/parameter.py
@@ -431,6 +431,50 @@ class DestinationArea(Enum):
     JAPAN = "JJ"
 
 
+class TemporaryChannelLevelNumeric(ParamNumeric):
+    """Single-channel Temporary Channel Level numeric parameter.
+
+    This represents one channel's TCL numeric parameter. It inherits from
+    ParamNumeric but overrides encoding/decoding to match the TCL format:
+    - Zero: '000'
+    - Positive: '+{HEX:2}'  (e.g. +2 -> '+02', +16 -> '+10')
+    - Negative: '-{HEX:2}'  (e.g. -1 -> '-01')
+
+    Numeric range: [-16, 16]
+    """
+
+    numeric_range = (-16, 16)
+    decimal = False
+    format_width = 3
+
+    @classmethod
+    def from_numeric(cls, numeric: int) -> Self:
+        if not cls.numeric_range[0] <= numeric <= cls.numeric_range[1]:
+            raise ValueError(f"Param outside of range: {numeric} in {cls.__name__}")
+        if numeric == 0:
+            raw = b"000"
+        else:
+            sign = b"+" if numeric > 0 else b"-"
+            absval = abs(numeric)
+            raw = sign + f"{absval:02X}".encode("ascii")
+        return cls(numeric, raw)
+
+    @classmethod
+    def parse(cls, parameter: bytes) -> int:
+        if len(parameter) != 3:
+            raise ValueError(f"Invalid TCL single-parameter length: {len(parameter)}")
+        if parameter == b"000":
+            return 0
+        sign = parameter[:1]
+        digits = parameter[1:3].decode("ascii")
+        try:
+            val = int(digits, 16)
+        except ValueError as exc:
+            raise ValueError(f"Invalid TCL digits: {digits}") from exc
+        return val if sign == b"+" else -val
+
+
+
 __all__ = [
     "InputSourceParam",
     "ListeningModeParam",

--- a/src/aioonkyo/status.py
+++ b/src/aioonkyo/status.py
@@ -21,6 +21,7 @@ from .parameter import (
     ToneParam,
     TunerPresetParam,
     VolumeParamNumeric,
+    TemporaryChannelLevelNumeric,
 )
 
 
@@ -195,6 +196,41 @@ class _ChannelMutingStatus(_KnownStatus):
 class ChannelMutingStatus(_ChannelMutingStatus):
     # TypeAlias doesn't work in dataclasses
     Param: TypeAlias = MutingParam
+
+
+@dataclass(match_args=False)
+class _TemporaryChannelLevelStatus(_KnownStatus):
+    kind: ClassVar[Kind] = Kind.TEMPORARY_CHANNEL_LEVEL
+
+    front_left: int | None
+    front_right: int | None
+    center: int | None
+    surround_left: int | None
+    surround_right: int | None
+    surround_back_left: int | None
+    surround_back_right: int | None
+    subwoofer: int | None
+    height_1_left: int | None
+    height_1_right: int | None
+    height_2_left: int | None
+    height_2_right: int | None
+    subwoofer_2: int | None
+
+    @classmethod
+    def parse(cls, code: Code, parameter: bytes) -> Self:
+        if len(parameter) != 13 * 3:
+            raise ValueError(f"Incorrect number of values in {cls.__name__}")
+
+        values = (TemporaryChannelLevelNumeric.parse(parameter[i : i + 3]) for i in range(0, len(parameter), 3))
+
+        self = cls(code, parameter, *values)
+        self._validate()
+        return self
+
+
+class TemporaryChannelLevelStatus(_TemporaryChannelLevelStatus):
+    # TypeAlias doesn't work in dataclasses
+    Param: TypeAlias = TemporaryChannelLevelNumeric
 
 
 @dataclass(match_args=False)
@@ -390,6 +426,7 @@ type ValidStatus = (
     | ToneStatus
     | TemperatureStatus
     | ChannelMutingStatus
+    | TemporaryChannelLevelStatus
     | AudioInformationStatus
     | VideoInformationStatus
     | FLDisplayStatus


### PR DESCRIPTION
This PR implements `TemporaryChannelLevel` command support, as described under [python-eiscp](https://github.com/arturpragacz/python-eiscp/blob/master/pyeiscp/commands.py#L250).

Tests:
- 2026-02-24: Working channel balance command sending to Pioneer VSX-LX303.
- 2026-04-18: Working Home Assistant integration, fixed status query.

Closes #2 